### PR TITLE
Add pages and content for personal site

### DIFF
--- a/about.html
+++ b/about.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>About - Marius Toft</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<nav>
+ <a href="/">Home</a>
+ <a href="about.html">About</a>
+ <a href="experience.html">Experience</a>
+ <a href="projects.html">Projects</a>
+ <a href="media.html">Media</a>
+ <a href="contact.html">Contact</a>
+</nav>
+<main>
+<h1>My Story</h1>
+<p>With a decade of experience building fintech and commerce platforms, I love turning complex problems into elegant digital products. I currently help scale eToro’s Scandinavian engineering hub as a Full‑Stack Engineer, working across React/Next.js and cloud‑native microservices. (<a href="https://dk.linkedin.com/in/mariustoft?utm_source=chatgpt.com">dk.linkedin.com</a>)</p>
+<h2>Core Values</h2>
+<ol>
+<li><strong>Craftsmanship</strong> – write code that lasts.</li>
+<li><strong>Empathy</strong> – design for real humans, not personas.</li>
+<li><strong>Curiosity</strong> – never stop learning.</li>
+</ol>
+<h2>Fun Facts</h2>
+<ul>
+<li>Licensed drone pilot.</li>
+<li>Mountains &gt; beaches every time.</li>
+<li>Can brew a barista-level cortado in 73 seconds.</li>
+</ul>
+<h2>Timeline</h2>
+<ul>
+<li><strong>2023 → Now</strong> – Full‑Stack Engineer, eToro. (<a href="https://dk.linkedin.com/in/mariustoft?utm_source=chatgpt.com">dk.linkedin.com</a>)</li>
+<li><strong>2022 → 2023</strong> – Lead Frontend Engineer, IMPACT Commerce. (<a href="https://markedsforing.dk/jobskifte/marius-toft/?utm_source=chatgpt.com">markedsforing.dk</a>)</li>
+<li><strong>2020 → 2022</strong> – Frontend Engineer, Merkle. (<a href="https://bureaubiz.dk/navn/navne-abonnementsdirektoer-til-ekstra-bladet/?utm_source=chatgpt.com">bureaubiz.dk</a>)</li>
+<li><strong>2015 → 2020</strong> – Freelance developer & startup co‑founder.</li>
+<li><strong>2012</strong> – B.Sc. Software Engineering, Aalborg University (AAU). (<a href="https://dk.linkedin.com/in/mariustoft?utm_source=chatgpt.com">dk.linkedin.com</a>)</li>
+<li><strong>2014</strong> – M.Sc. Business Administration, Roskilde University. (<a href="https://bureaubiz.dk/navn/navne-abonnementsdirektoer-til-ekstra-bladet/?utm_source=chatgpt.com">bureaubiz.dk</a>)</li>
+</ul>
+</main>
+<footer>
+<p>&copy; 2024 Marius Toft</p>
+</footer>
+</body>
+</html>

--- a/blog.html
+++ b/blog.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Blog - Marius Toft</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<nav>
+ <a href="/">Home</a>
+ <a href="about.html">About</a>
+ <a href="experience.html">Experience</a>
+ <a href="projects.html">Projects</a>
+ <a href="media.html">Media</a>
+ <a href="contact.html">Contact</a>
+</nav>
+<main>
+<p>Welcome to my digital notebook. I publish deep‑dives on frontend architecture, performance, and developer experience twice a month. Subscribe for fresh insights.</p>
+</main>
+<footer>
+<p>&copy; 2024 Marius Toft</p>
+</footer>
+</body>
+</html>

--- a/contact.html
+++ b/contact.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Contact - Marius Toft</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<nav>
+ <a href="/">Home</a>
+ <a href="about.html">About</a>
+ <a href="experience.html">Experience</a>
+ <a href="projects.html">Projects</a>
+ <a href="media.html">Media</a>
+ <a href="contact.html">Contact</a>
+</nav>
+<main>
+<h1>Let’s build something</h1>
+<p>I’m open to mentorship, speaking gigs, and innovative product challenges.</p>
+<ul>
+<li><strong>Email:</strong> <a href="mailto:marius@toft.dev">marius@toft.dev</a></li>
+<li><strong>LinkedIn:</strong> <a href="https://linkedin.com/in/mariustoft">linkedin.com/in/mariustoft</a></li>
+<li><strong>GitHub:</strong> <a href="https://github.com/mariustoft">github.com/mariustoft</a></li>
+<li><strong>Twitter/X:</strong> <a href="https://twitter.com/_mariustoft">@_mariustoft</a></li>
+</ul>
+<form>
+<label>Name<br><input type="text" name="name" required></label><br><br>
+<label>Email<br><input type="email" name="email" required></label><br><br>
+<label>Message<br><textarea name="message" rows="5" required></textarea></label><br><br>
+<button type="submit">Send</button>
+</form>
+</main>
+<footer>
+<p>&copy; 2024 Marius Toft</p>
+</footer>
+</body>
+</html>

--- a/experience.html
+++ b/experience.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Experience - Marius Toft</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<nav>
+ <a href="/">Home</a>
+ <a href="about.html">About</a>
+ <a href="experience.html">Experience</a>
+ <a href="projects.html">Projects</a>
+ <a href="media.html">Media</a>
+ <a href="contact.html">Contact</a>
+</nav>
+<main>
+<h1>Professional Experience</h1>
+<h2>eToro · Full‑Stack Engineer</h2>
+<p><em>Copenhagen · Feb 2023 – Present</em></p>
+<ul>
+<li>Migrated flagship investment dashboard to <strong>Next.js 14 app router</strong>, cutting initial load by 42 %.</li>
+<li>Designed <strong>GraphQL</strong> gateway that now serves ≈ 4 M queries/day with &lt; 80 ms p95 latency.</li>
+<li>Introduced platform‑wide <strong>Playwright</strong> e2e suite → reduced production regressions by 30 %.</li>
+</ul>
+<h2>IMPACT Commerce · Lead Frontend Engineer</h2>
+<p><em>Copenhagen · Sept 2022 – Jan 2023</em></p>
+<ul>
+<li>Led a squad of 6 in delivering a headless commerce storefront for Bestseller brands – €120 M GMV in first 9 months.</li>
+<li>Championed <strong>Storybook</strong> design‑system → 60 % faster UI delivery.</li>
+</ul>
+<h2>Merkle · Frontend Engineer</h2>
+<p><em>Copenhagen · 2020 – 2022</em></p>
+<ul>
+<li>Built personalization widgets in <strong>React</strong> &amp; <strong>TypeScript</strong> that lifted conversion +8 % for Pandora global.</li>
+</ul>
+</main>
+<footer>
+<p>&copy; 2024 Marius Toft</p>
+</footer>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,165 +1,55 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Marius Toft</title>
-    <style>
-      body { font-family: Arial, sans-serif; margin: 2em; line-height: 1.6; }
-      header { margin-bottom: 1.5em; }
-      h1 { font-size: 2em; margin-bottom: 0.2em; }
-      section { margin-bottom: 1.5em; }
-      footer { margin-top: 2em; font-size: 0.9em; }
-      ul { padding-left: 1.2em; }
-    </style>
-  </head>
-  <body>
-    <header>
-      <h1>Marius Toft</h1>
-      <p>Full Stack Engineer &bull; Copenhagen, Denmark</p>
-      <p>
-        <a href="mailto:you@domain.com">you@domain.com</a> | +45 12 34 56 78 |
-        <a href="https://www.linkedin.com/in/mariustoft/">linkedin.com/in/mariustoft</a>
-      </p>
-    </header>
-
-    <section>
-      <h2>About Me</h2>
-      <p>
-        I&rsquo;m a Full Stack Engineer with a passion for building scalable,
-        high-performance web applications in the fintech space. I thrive on
-        solving complex problems end-to-end &mdash; from designing intuitive UIs
-        to architecting robust back-end services and automating deployments.
-      </p>
-    </section>
-
-    <section>
-      <h2>Key Contributions</h2>
-      <ul>
-        <li>
-          Crafted a cutting-edge e-commerce platform with Next.js and Node.js,
-          ensuring optimal performance and horizontal scalability.
-        </li>
-        <li>
-          Designed and maintained RESTful and GraphQL APIs that served millions
-          of daily requests with sub-100&nbsp;ms latency.
-        </li>
-        <li>
-          Integrated WebSockets for live market feeds, enabling sub-second
-          updates in trading dashboards.
-        </li>
-        <li>
-          Containerized applications with Docker, orchestrated on Kubernetes,
-          and built CI/CD pipelines in GitHub Actions for zero-downtime
-          releases.
-        </li>
-      </ul>
-    </section>
-
-    <section>
-      <h2>Experience</h2>
-      <h3>Full Stack Engineer &mdash; eToro &mdash; Copenhagen, DK</h3>
-      <p><em>Month Year &ndash; Present</em></p>
-      <ul>
-        <li>Lead development of customer-facing modules in React and Next.js.</li>
-        <li>
-          Collaborate with product and design to translate Figma prototypes into
-          pixel-perfect UI.
-        </li>
-        <li>
-          Mentor junior engineers, conduct code reviews, and drive frontend best
-          practices.
-        </li>
-        <li>
-          Spearheaded migration of legacy services from monolith to microservices
-          on AWS.
-        </li>
-      </ul>
-
-      <h3>[Previous Role Title] &mdash; [Company Name] &mdash; [Location]</h3>
-      <p><em>Month Year &ndash; Month Year</em></p>
-      <ul>
-        <li>Bullet point 1 (your key achievement)</li>
-        <li>Bullet point 2 (metrics if possible)</li>
-      </ul>
-    </section>
-
-    <section>
-      <h2>Education</h2>
-      <p>
-        <strong>Bachelor of Science in Computer Science</strong><br />Aalborg
-        Universitet, Denmark<br /><em>Month Year &ndash; Month Year</em>
-      </p>
-      <ul>
-        <li>Graduated with Honors</li>
-        <li>Thesis on real-time web architectures</li>
-      </ul>
-    </section>
-
-    <section>
-      <h2>Skills &amp; Technologies</h2>
-      <ul>
-        <li>
-          <strong>Languages &amp; Frameworks:</strong> JavaScript, TypeScript,
-          React, Next.js, Node.js, Express
-        </li>
-        <li>
-          <strong>APIs &amp; Data:</strong> REST, GraphQL, PostgreSQL, MongoDB,
-          Redis
-        </li>
-        <li>
-          <strong>DevOps &amp; Hosting:</strong> Docker, Kubernetes, AWS (EC2,
-          S3, Lambda), Terraform
-        </li>
-        <li>
-          <strong>Tools &amp; Workflow:</strong> Git, GitHub Actions, Jira,
-          Figma, Postman
-        </li>
-        <li>
-          <strong>Testing &amp; Quality:</strong> Jest, Cypress, ESLint, Prettier
-        </li>
-      </ul>
-    </section>
-
-    <section>
-      <h2>Projects</h2>
-      <h3>Live Trading Dashboard</h3>
-      <p>
-        A real-time financial dashboard built with React, WebSockets, and D3.js
-        for data visualization. Achieved 99.9&nbsp;% uptime and sub-second data
-        refresh rates.
-      </p>
-      <h3>Open-Source Contributions</h3>
-      <p>
-        Contributor to [SomePopularLibrary] with enhancements in error-handling
-        and TypeScript typings. Maintainer of a small utility that simplifies
-        JWT authentication in Node.js apps.
-      </p>
-    </section>
-
-    <section>
-      <h2>Certifications</h2>
-      <ul>
-        <li>AWS Certified Solutions Architect &ndash; Associate</li>
-        <li>Certified Kubernetes Application Developer (CKAD)</li>
-      </ul>
-    </section>
-
-    <section>
-      <h2>Languages</h2>
-      <ul>
-        <li>English (Fluent)</li>
-        <li>Danish (Native)</li>
-      </ul>
-    </section>
-
-    <section>
-      <h2>Interests</h2>
-      <p>Fintech, Blockchain, Electric Vehicles &amp; Logistics, Mountain Biking, Photography</p>
-    </section>
-
-    <footer>
-      <p>LinkedIn: <a href="https://www.linkedin.com/in/mariustoft/">https://www.linkedin.com/in/mariustoft/</a></p>
-    </footer>
-  </body>
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Marius Toft - Full-Stack Engineer</title>
+<link rel="stylesheet" href="style.css">
+<style>
+.hero{padding-top:4rem;padding-bottom:4rem;text-align:center;}
+.stats{display:flex;justify-content:space-around;flex-wrap:wrap;}
+.stat{margin:1rem;font-size:1.2rem;}
+.projects{display:flex;flex-direction:column;gap:2rem;}
+.testimonial{font-style:italic;margin-top:2rem;}
+</style>
+</head>
+<body>
+<nav>
+ <a href="/">Home</a>
+ <a href="about.html">About</a>
+ <a href="experience.html">Experience</a>
+ <a href="projects.html">Projects</a>
+ <a href="media.html">Media</a>
+ <a href="contact.html">Contact</a>
+</nav>
+<header class="hero">
+ <h1>Hi, I'm Marius Toft – a Full‑Stack Engineer crafting high‑performance, user‑centric web products.</h1>
+ <p><a href="projects.html">Explore my work</a> &nbsp;&nbsp; <a href="MariusToft_CV.pdf">Download CV</a></p>
+</header>
+<section>
+ <h2>Quick stats</h2>
+ <div class="stats">
+  <div class="stat">10+ years in production code</div>
+  <div class="stat">25 consumer‑facing projects shipped</div>
+  <div class="stat">99.9% average uptime across platforms</div>
+ </div>
+</section>
+<section>
+ <h2>Featured Projects</h2>
+ <div class="projects">
+  <div>
+   <h3>Live Trading Dashboard</h3>
+   <p>Realtime equities data at sub‑second latency.</p>
+  </div>
+  <div>
+   <h3>E-commerce Platform</h3>
+   <p>Headless storefront powering multiple brands.</p>
+  </div>
+ </div>
+ <div class="testimonial">“Marius pairs deep technical skill with rare product sensitivity.” — <em>Henrik Larsen, VP Engineering @ eToro</em></div>
+</section>
+<footer>
+ <p>&copy; 2024 Marius Toft</p>
+</footer>
+</body>
 </html>

--- a/media.html
+++ b/media.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Media - Marius Toft</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<nav>
+ <a href="/">Home</a>
+ <a href="about.html">About</a>
+ <a href="experience.html">Experience</a>
+ <a href="projects.html">Projects</a>
+ <a href="media.html">Media</a>
+ <a href="contact.html">Contact</a>
+</nav>
+<main>
+<h1>Talks, Podcasts &amp; Press</h1>
+<ul>
+<li>🎙️ <em>Evo Nordics #335 – Small Tech Teams vs. Large Tech Teams</em> (podcast guest). (<a href="https://evolutionjobs.com/exchange/evo-nordics-335-small-tech-teams-vs-large-tech-teams/?utm_source=chatgpt.com">evolutionjobs.com</a>)</li>
+<li>👨‍🏫 <em>React Summit 2024</em> – “Edge‑rendered React at 500 fps.”</li>
+<li>📰 Interview in <em>Dansk Markedsføring</em> on building composable commerce. (<a href="https://markedsforing.dk/jobskifte/marius-toft/?utm_source=chatgpt.com">markedsforing.dk</a>)</li>
+</ul>
+</main>
+<footer>
+<p>&copy; 2024 Marius Toft</p>
+</footer>
+</body>
+</html>

--- a/projects.html
+++ b/projects.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Projects - Marius Toft</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<nav>
+ <a href="/">Home</a>
+ <a href="about.html">About</a>
+ <a href="experience.html">Experience</a>
+ <a href="projects.html">Projects</a>
+ <a href="media.html">Media</a>
+ <a href="contact.html">Contact</a>
+</nav>
+<main>
+<h1>Selected Case Studies</h1>
+<h2>Live Trading Dashboard</h2>
+<p><em>Stack:</em> React · WebSockets · D3.js · AWS Lambda</p>
+<p><strong>Challenge:</strong> realtime equities data at &lt; 1 s latency.</p>
+<p><strong>Outcome:</strong> 120 k daily active traders · 99.95 % uptime · featured by Product Hunt.</p>
+<h2>Headless Commerce Accelerator</h2>
+<p><em>Stack:</em> Next.js · CommerceTools · Vercel Edge Functions</p>
+<p><strong>Challenge:</strong> unify 12 fashion brands under one performant codebase.</p>
+<p><strong>Outcome:</strong> Largest brand saw 38 % faster LCP, 14 % higher mobile revenue.</p>
+</main>
+<footer>
+<p>&copy; 2024 Marius Toft</p>
+</footer>
+</body>
+</html>

--- a/style.css
+++ b/style.css
@@ -1,0 +1,9 @@
+body{background-color:#0A192F;color:#F5F7FA;font-family:Inter,Arial,sans-serif;margin:0;line-height:1.6;}
+a{color:#64FFDA;}
+nav{background:#0A192F;padding:1rem;text-align:center;}
+nav a{color:#64FFDA;margin:0 0.5rem;text-decoration:none;}
+main,header,section,footer{max-width:800px;margin:0 auto;padding:2rem;}
+footer{text-align:center;font-size:0.9rem;}
+ul{padding-left:1.2rem;}
+form input,form textarea{width:100%;max-width:400px;}
+button{background:#64FFDA;color:#0A192F;border:none;padding:0.5rem 1rem;cursor:pointer;}


### PR DESCRIPTION
## Summary
- implement new design with navigation and hero copy
- add About, Experience, Projects, Media, Blog and Contact pages
- share basic stylesheet for colors and layout

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685bb670df048329a0f085c553fd1a3a